### PR TITLE
Add support for ordering rule for native classes

### DIFF
--- a/lib/rules/order-in-components.js
+++ b/lib/rules/order-in-components.js
@@ -58,11 +58,11 @@ module.exports = {
       order.splice(indexOfLifecycleHook, 1, componentLifeCycleHooks);
     }
 
-    const filePath = context.getFilename();
-
     return {
       CallExpression(node) {
-        if (!ember.isEmberComponent(node, filePath)) return;
+        if (!ember.isEmberComponent(context, node)) {
+          return;
+        }
 
         reportUnorderedProperties(node, context, 'component', order);
       },


### PR DESCRIPTION
This adds support for native classes to the `order-in-components` custom
rule.
More [here](https://github.com/ember-cli/eslint-plugin-ember/pull/558)

Fixes error 
```
AssertionError [ERR_ASSERTION]: Function should only be called on a `CallExpression` (classic class) or `ClassDeclaration` (native class)
```

**NOTE:** However, this rule does seems to not work properly. Also, ember stopped recommending this rule from what I can see and it has no support for native classes yet... so we will have to disable it too likely